### PR TITLE
SRVCOM-2728: High CPU/memory usage of istio-proxies when adding ksvcs

### DIFF
--- a/templates/common-tenant-sidecar.yaml
+++ b/templates/common-tenant-sidecar.yaml
@@ -1,0 +1,24 @@
+{{- range $ns := $.Values.namespaces }}
+---
+# Restrict namespace {{ $ns }} sidecars egress rules to tenants specific namespaces so that
+# application sidecars don't consumer a ton of memory/cpu.
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: default
+  namespace: {{ $ns }}
+spec:
+  egress:
+    - hosts:
+        {{- range $tns := $.Values.namespaces }}
+        - "{{ $tns }}/*"
+        {{ end }}
+        - "{{ $.Values.istioNamespace }}/*"
+        {{- if $.Values.serving.enabled }}
+        - "knative-serving/*"
+        {{ end }}
+        {{- if $.Values.eventing.enabled }}
+        - "knative-eventing/*"
+        {{ end }}
+---
+{{- end }}


### PR DESCRIPTION
Add `Sidecar` configuration in tenant's namespaces to restrict egress rules and reduce cpu/memory usage.

Documentation https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/service_mesh/service-mesh-2-x#ossm-routing-sidecar_traffic-management


This command will generate these 2 Sidecar resources 
```shell
helm template ./ --values tests/values.yaml
```

```yaml
# ...
---
# Source: knative-istio-authz-onboarding/templates/common-tenant-sidecar.yaml
# Restrict namespace ns1 sidecars egress rules to tenants specific namespaces so that
# application sidecars don't consumer a ton of memory/cpu.
apiVersion: networking.istio.io/v1alpha3
kind: Sidecar
metadata:
  name: default
  namespace: ns1
spec:
  egress:
    - hosts:
        - "ns1/*"
        
        - "ns2/*"
        
        - "istio-system/*"
        - "knative-serving/*"
        
        - "knative-eventing/*"
---
# Source: knative-istio-authz-onboarding/templates/common-tenant-sidecar.yaml
---
# Restrict namespace ns2 sidecars egress rules to tenants specific namespaces so that
# application sidecars don't consumer a ton of memory/cpu.
apiVersion: networking.istio.io/v1alpha3
kind: Sidecar
metadata:
  name: default
  namespace: ns2
spec:
  egress:
    - hosts:
        - "ns1/*"
        
        - "ns2/*"
        
        - "istio-system/*"
        - "knative-serving/*"
        
        - "knative-eventing/*"
```