### PR TITLE
Change chart name to redhat-knative-istio-authz

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: knative-istio-authz-onboarding
+name: knative-istio-authz
 description: Helm chart to onboard a set of authorization-based isolated namespaces to Knative when using Istio.
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Imaging we want to onboard a new tenant named `tenant-1` to Knative composed of 
 
 2. Install the Helm chart
    ```shell
-   helm install oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version 1.31.0 --set "name=tenant-1" --set "namespaces={ns1, ns2}"
+   helm install oci://quay.io/openshift-knative/knative-istio-authz --version 1.31.0 --set "name=tenant-1" --set "namespaces={ns1, ns2}"
    ```
    or, view the resources you would need to onboard the project:
    ```shell
-   helm template oci://quay.io/openshift-knative/knative-istio-authz-onboarding --version 1.31.0 --set "name=tenant-1" --set "namespaces={ns1, ns2}"
+   helm template oci://quay.io/openshift-knative/knative-istio-authz --version 1.31.0 --set "name=tenant-1" --set "namespaces={ns1, ns2}"
    ```
 
 ## Development
@@ -43,7 +43,7 @@ helm package ./
 Push the chart to your own account by running the following command:
 
 ```shell
-helm push knative-istio-authz-onboarding-0.1.0.tgz oci://quay.io/<your-username>
+helm push knative-istio-authz-0.1.0.tgz oci://quay.io/<your-username>
 ```
 
 The chart is automatically pushed to quay.io/openshift-knative on  `main` and `release-*` branches using CI.


### PR DESCRIPTION
As per the discussion at https://redhat-internal.slack.com/archives/CKR568L8G/p1700479430034559?thread_ts=1700032492.463009&cid=CKR568L8G

we are changing the chart name to **redhat-knative-istio-authz**

cc @pierDipi