### PR TITLE
Add knative-serving-ingress for OSSM 3.x

### DIFF
--- a/templates/common-allow-knative-to-ns.yaml
+++ b/templates/common-allow-knative-to-ns.yaml
@@ -17,6 +17,7 @@ spec:
               - "{{ $v }}"
               {{- end }}
               - "knative-serving"
+              - "knative-serving-ingress"
               - {{ $.Values.istioNamespace | quote }}
 {{ end }}
 {{- if $.Values.eventing.enabled }}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/SRVKS-1281

# Changes
- Adds `knative-serving-ingress` to policies, as this is where the istio-ingressgateway will be for OSSM 3.x


/assign @skonto 
